### PR TITLE
Refactored repeating instuctions

### DIFF
--- a/Battle_Klasse.py
+++ b/Battle_Klasse.py
@@ -10,51 +10,76 @@ class Battle:
         self.enemy_move = None
         self.altar = altar
         self.player_dead_pokemon = []
-
-    def player_attack_physic(self):
-        spieler_active_poke_init = getattr(self.spieler_active_poke, "init")
-        enemy_active_poke_init = getattr(self.enemy_active_poke, "init")
-
-        if spieler_active_poke_init > enemy_active_poke_init:
+    
+    def __calc_damage_physic(self, attacker, defender) -> float:
+        return round((attacker.level * 0.4 + 2)
+                      * attacker.atk
+                      * attacker.attacken[0].atkdmg
+                      / (10 * defender.defence), 2)
+    
+    def __calc_damage_special(self, attacker, defender) -> float:
+        return round((attacker.level * 0.4 + 2)
+                      * attacker.spatk
+                      * attacker.attacken[0].atkdmg
+                      / (10 * defender.spdef), 2)
+    
+    def __active_fainted(self, pokemon) -> bool:
+        if pokemon.currentkp < 0:
+            pokemon.currentkp = 0
+            return True
+        return False
+    
+    def __team_dead(self, team) -> bool:
+        if len(team) > 0:
+            return True
+        return False
+    
+    def __swap_player_pokemon(self) -> None:
+        moved_pokemon = self.spieler_active_poke
+        self.spieler_poke_team.remove(moved_pokemon)
+        self.player_dead_pokemon.append(moved_pokemon)
+    
+    def __end_turn_player_win(self) -> None:
+        self.spieler_active_poke.ep += 100
+        self.spieler_active_poke.check_level_up()
+        self.altar.pokemon_bodies += 1
+    
+    def player_attack_physic(self) -> None:
+        if self.spieler_active_poke.init > self.enemy_active_poke.init:
             # wählt den Move des Gegners
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             # Schaden der Spielerattacke wird berechnet
-            spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.atk * self.spieler_active_poke.attacken[0].atkdmg / (10 * self.enemy_active_poke.defence), 2)
-            self.enemy_active_poke.currentkp -= spieler_dmg
-            if self.enemy_active_poke.currentkp > 0:
+            self.enemy_active_poke.currentkp -= self.__calc_damage_physic(self.spieler_active_poke,
+                                                                          self.enemy_active_poke)
+            if not self.__active_fainted(self.enemy_active_poke):
                 # Gegner hat überlebt -> physiche Attacke
                 if self.enemy_move == "attack_physic":
-                    self.spieler_active_poke.currentkp -= self.enemy_attack_physic()    # Gegnerattacke
-                    if self.spieler_active_poke.currentkp <= 0:
+                    self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                    self.spieler_active_poke)
+                    if self.__active_fainted(self.spieler_active_poke):
                         # Spieler Pokemon austauschen bzw Game Over
-                        moved_pokemon = self.spieler_active_poke
-                        self.spieler_poke_team.remove(moved_pokemon)
-                        self.player_dead_pokemon.append(moved_pokemon)
-                        if len(self.spieler_poke_team) >= 1:
+                        self.__swap_player_pokemon()
+                        if not self.__team_dead(self.spieler_poke_team):
                             self.spieler_active_poke = self.spieler_poke_team[0]
                         else:
                             return "game_over_player"
                 # Gegner hat überlebt -> spezial-Attacke
                 elif self.enemy_move == "attack_special":
-                    self.spieler_active_poke.currentkp -= self.enemy_attack_special()   # Gegnerattacke
-                    if self.spieler_active_poke.currentkp <= 0:
+                    self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                     self.spieler_active_poke)
+                    if self.__active_fainted(self.spieler_active_poke):
                         # Spieler Pokemon austauschen bzw Game Over
-                        moved_pokemon = self.spieler_active_poke
-                        self.spieler_poke_team.remove(moved_pokemon)
-                        self.player_dead_pokemon.append(moved_pokemon)
-                        if len(self.spieler_poke_team) >= 1:
+                        self.__swap_player_pokemon()
+                        if not self.__team_dead(self.spieler_poke_team):
                             self.spieler_active_poke = self.spieler_poke_team[0]
                         else:
                             return "game_over_player"
             else:
-                # EP an aktives Spieler Pokemon geben
-                self.spieler_active_poke.ep += 100
-                self.spieler_active_poke.check_level_up()
-                self.altar.pokemon_bodies += 1
+                self.__end_turn_player_win()
                 # Gegner Pokemon austauschen bzw Game Over
                 self.enemy_poke_team.remove(self.enemy_active_poke)
-                if len(self.enemy_poke_team) >= 1:
+                if not self.__team_dead(self.enemy_poke_team):
                     self.enemy_active_poke = self.enemy_poke_team[0]
                 else:
                     return "game_over_enemy"
@@ -63,54 +88,46 @@ class Battle:
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             if self.enemy_move == "attack_physic":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_physic()  # Gegnerattacke
-                if self.spieler_active_poke.currentkp <= 0:
+                self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                self.spieler_active_poke)
+                if self.__active_fainted(self.spieler_active_poke):
                     # Spieler Pokemon austauschen bzw Game Over
-                    moved_pokemon = self.spieler_active_poke
-                    self.spieler_poke_team.remove(moved_pokemon)
-                    self.player_dead_pokemon.append(moved_pokemon)
-                    if len(self.spieler_poke_team) >= 1:
+                    self.__swap_player_pokemon()
+                    if not self.__team_dead(self.spieler_poke_team):
                         self.spieler_active_poke = self.spieler_poke_team[0]
                     else:
                         return "game_over_player"
                 else:
                     # Schaden der Spielerattacke wird berechnet
-                    spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.atk * self.spieler_active_poke.attacken[0].atkdmg / (10 * self.enemy_active_poke.defence), 2)
-                    self.enemy_active_poke.currentkp -= spieler_dmg
-                    if self.enemy_active_poke.currentkp < 0:
-                        # EP an aktives Spieler Pokemon geben
-                        self.spieler_active_poke.ep += 100
-                        self.spieler_active_poke.check_level_up()
-                        self.altar.pokemon_bodies += 1
+                    self.enemy_active_poke.currentkp -= self.__calc_damage_physic(self.spieler_active_poke,
+                                                                                  self.enemy_active_poke)
+                    if self.__active_fainted(self.enemy_active_poke):
+                        self.__end_turn_player_win()
                         # Gegner Pokemon austauschen bzw Game Over
                         self.enemy_poke_team.remove(self.enemy_active_poke)
-                        if len(self.enemy_poke_team) >= 1:
+                        if not self.__team_dead(self.enemy_poke_team):
                             self.enemy_active_poke = self.enemy_poke_team[0]
                         else:
                             return "game_over_enemy"
             elif self.enemy_move == "attack_special":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_special()  # Gegnerattacke
-                if self.spieler_active_poke.currentkp <= 0:
+                self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                 self.spieler_active_poke)
+                if self.__active_fainted(self.spieler_active_poke):
                     # Spieler Pokemon austauschen bzw Game Over
-                    moved_pokemon = self.spieler_active_poke
-                    self.spieler_poke_team.remove(moved_pokemon)
-                    self.player_dead_pokemon.append(moved_pokemon)
-                    if len(self.spieler_poke_team) >= 1:
+                    self.__swap_player_pokemon()
+                    if not self.__team_dead(self.spieler_poke_team):
                         self.spieler_active_poke = self.spieler_poke_team[0]
                     else:
                         return "game_over_player"
                 else:
                     # Schaden der Spielerattacke wird berechnet
-                    spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.atk * self.spieler_active_poke.attacken[0].atkdmg / (10 * self.enemy_active_poke.defence), 2)
-                    self.enemy_active_poke.currentkp -= spieler_dmg
-                    if self.enemy_active_poke.currentkp < 0:
-                        # EP an aktives Spieler Pokemon geben
-                        self.spieler_active_poke.ep += 100
-                        self.spieler_active_poke.check_level_up()
-                        self.altar.pokemon_bodies += 1
+                    self.enemy_active_poke.currentkp -= self.__calc_damage_special(self.spieler_active_poke,
+                                                                                   self.enemy_active_poke)
+                    if self.__active_fainted(self.enemy_active_poke):
+                        self.__end_turn_player_win()
                         # Gegner Pokemon austauschen bzw Game Over
                         self.enemy_poke_team.remove(self.enemy_active_poke)
-                        if len(self.enemy_poke_team) >= 1:
+                        if not self.__team_dead(self.enemy_poke_team):
                             self.enemy_active_poke = self.enemy_poke_team[0]
                         else:
                             return "game_over_enemy"
@@ -126,12 +143,13 @@ class Battle:
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             # Schaden der Spielerattacke wird berechnet
-            spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.spatk * self.spieler_active_poke.attacken[1].atkdmg / (10 * self.enemy_active_poke.spdef), 2)
-            self.enemy_active_poke.currentkp -= spieler_dmg
+            self.enemy_active_poke.currentkp -= self.__calc_damage_special(self.spieler_active_poke,
+                                                                           self.enemy_active_poke)
             if self.enemy_active_poke.currentkp > 0:
                 # Gegner hat überlebt -> physiche Attacke
                 if self.enemy_move == "attack_physic":
-                    self.spieler_active_poke.currentkp -= self.enemy_attack_physic()    # Gegnerattacke
+                    self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                    self.spieler_active_poke)
                     if self.spieler_active_poke.currentkp <= 0:
                         # Spieler Pokemon austauschen bzw Game Over
                         moved_pokemon = self.spieler_active_poke
@@ -143,7 +161,8 @@ class Battle:
                             return "game_over_player"
                 # Gegner hat überlebt -> spezial-Attacke
                 elif self.enemy_move == "attack_special":
-                    self.spieler_active_poke.currentkp -= self.enemy_attack_special()   # Gegnerattacke
+                    self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                     self.spieler_active_poke)
                     if self.spieler_active_poke.currentkp <= 0:
                         # Spieler Pokemon austauschen bzw Game Over
                         moved_pokemon = self.spieler_active_poke
@@ -169,7 +188,8 @@ class Battle:
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             if self.enemy_move == "attack_physic":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_physic()  # Gegnerattacke
+                self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                self.spieler_active_poke)
                 if self.spieler_active_poke.currentkp <= 0:
                     # Spieler Pokemon austauschen bzw Game Over
                     moved_pokemon = self.spieler_active_poke
@@ -181,8 +201,8 @@ class Battle:
                         return "game_over_player"
                 else:
                     # Schaden der Spielerattacke wird berechnet
-                    spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.spatk * self.spieler_active_poke.attacken[1].atkdmg / (10 * self.enemy_active_poke.spdef), 2)
-                    self.enemy_active_poke.currentkp -= spieler_dmg
+                    self.enemy_active_poke.currentkp -= self.__calc_damage_special(self.spieler_active_poke,
+                                                                                   self.enemy_active_poke)
                     if self.enemy_active_poke.currentkp < 0:
                         # EP an aktives Spieler Pokemon geben und Levelup checken
                         self.spieler_active_poke.ep += 100
@@ -195,7 +215,8 @@ class Battle:
                         else:
                             return "game_over_enemy"
             elif self.enemy_move == "attack_special":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_special()  # Gegnerattacke
+                self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                 self.spieler_active_poke)
                 if self.spieler_active_poke.currentkp <= 0:
                     # Spieler Pokemon austauschen bzw Game Over
                     moved_pokemon = self.spieler_active_poke
@@ -207,8 +228,8 @@ class Battle:
                         return "game_over_player"
                 else:
                     # Schaden der Spielerattacke wird berechnet
-                    spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.spatk * self.spieler_active_poke.attacken[1].atkdmg / (10 * self.enemy_active_poke.spdef), 2)
-                    self.enemy_active_poke.currentkp -= spieler_dmg
+                    self.enemy_active_poke.currentkp -= self.__calc_damage_special(self.spieler_active_poke,
+                                                                                   self.enemy_active_poke)
                     if self.enemy_active_poke.currentkp < 0:
                         # EP an aktives Spieler Pokemon geben
                         self.spieler_active_poke.ep += 100
@@ -238,11 +259,3 @@ class Battle:
             healed_pokemon = self.spieler_poke_team[count]
             healed_pokemon.currentkp = healed_pokemon.maxkp
             count += 1
-
-    def enemy_attack_physic(self):
-        enemy_dmg = round((self.enemy_active_poke.level * 0.4 + 2) * self.enemy_active_poke.atk * self.enemy_active_poke.attacken[0].atkdmg / (10 * self.spieler_active_poke.defence), 2)
-        return enemy_dmg
-
-    def enemy_attack_special(self):
-        enemy_dmg = round((self.enemy_active_poke.level * 0.4 + 2) * self.enemy_active_poke.spatk * self.enemy_active_poke.attacken[1].atkdmg / (10 * self.spieler_active_poke.spdef), 2)
-        return enemy_dmg


### PR DESCRIPTION
Put repeating instructions, such as swapping pokemon and the repeat of player/computer damage calculations into their own methods for reuse.
Omitted repeated defining of spieler_dmg variables.

Realistically, the attack logic methods should be split into smaller methods even further, but that's a big undertaking.
My take on it would be separate enemy and player move methods, of which then only the order needs to be adjusted depending on initiative.