### PR TITLE
Refactor von wiederverwendeten Anweisungen in Methoden

### DIFF
--- a/Battle_Klasse.py
+++ b/Battle_Klasse.py
@@ -11,6 +11,38 @@ class Battle:
         self.altar = altar
         self.player_dead_pokemon = []
 
+    def __calc_damage_physic(self, attacker, defender) -> float:
+        return round((attacker.level * 0.4 + 2)
+                      * attacker.atk
+                      * attacker.attacken[0].atkdmg
+                      / (10 * defender.defence), 2)
+
+    def __calc_damage_special(self, attacker, defender) -> float:
+        return round((attacker.level * 0.4 + 2)
+                      * attacker.spatk
+                      * attacker.attacken[0].atkdmg
+                      / (10 * defender.spdef), 2)
+
+    def __active_fainted(self, active_pokemon) -> bool:
+        if active_pokemon.currentkp < 0:
+            active_pokemon.currentkp = 0
+            return True
+        return False
+
+    def __team_dead(self, team) -> bool:
+        if len(team) <= 0:
+            return True
+        return False
+
+    def __process_fainted(self, active_pokemon) -> None:
+        self.player_dead_pokemon.append(active_pokemon)
+        self.spieler_poke_team.remove(active_pokemon)
+
+    def __process_player_win(self) -> None:
+        self.spieler_active_poke.ep += 100
+        self.spieler_active_poke.check_level_up()
+        self.altar.pokemon_bodies += 1
+
     def player_attack_physic(self):
         spieler_active_poke_init = getattr(self.spieler_active_poke, "init")
         enemy_active_poke_init = getattr(self.enemy_active_poke, "init")
@@ -20,41 +52,37 @@ class Battle:
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             # Schaden der Spielerattacke wird berechnet
-            spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.atk * self.spieler_active_poke.attacken[0].atkdmg / (10 * self.enemy_active_poke.defence), 2)
-            self.enemy_active_poke.currentkp -= spieler_dmg
+            self.enemy_active_poke.currentkp -= self.__calc_damage_physic(self.spieler_active_poke,
+                                                                          self.enemy_active_poke)
             if self.enemy_active_poke.currentkp > 0:
                 # Gegner hat überlebt -> physiche Attacke
                 if self.enemy_move == "attack_physic":
-                    self.spieler_active_poke.currentkp -= self.enemy_attack_physic()    # Gegnerattacke
-                    if self.spieler_active_poke.currentkp <= 0:
+                    self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                    self.spieler_active_poke)
+                    if self.__active_fainted(self.spieler_active_poke):
                         # Spieler Pokemon austauschen bzw Game Over
-                        moved_pokemon = self.spieler_active_poke
-                        self.spieler_poke_team.remove(moved_pokemon)
-                        self.player_dead_pokemon.append(moved_pokemon)
-                        if len(self.spieler_poke_team) >= 1:
+                        self.__process_fainted(self.spieler_active_poke)
+                        if not self.__team_dead(self.spieler_poke_team):
                             self.spieler_active_poke = self.spieler_poke_team[0]
                         else:
                             return "game_over_player"
                 # Gegner hat überlebt -> spezial-Attacke
                 elif self.enemy_move == "attack_special":
-                    self.spieler_active_poke.currentkp -= self.enemy_attack_special()   # Gegnerattacke
-                    if self.spieler_active_poke.currentkp <= 0:
+                    self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                     self.spieler_active_poke)
+                    if self.__active_fainted(self.spieler_active_poke):
                         # Spieler Pokemon austauschen bzw Game Over
-                        moved_pokemon = self.spieler_active_poke
-                        self.spieler_poke_team.remove(moved_pokemon)
-                        self.player_dead_pokemon.append(moved_pokemon)
-                        if len(self.spieler_poke_team) >= 1:
+                        self.__process_fainted(self.spieler_active_poke)
+                        if not self.__team_dead(self.spieler_poke_team):
                             self.spieler_active_poke = self.spieler_poke_team[0]
                         else:
                             return "game_over_player"
             else:
                 # EP an aktives Spieler Pokemon geben
-                self.spieler_active_poke.ep += 100
-                self.spieler_active_poke.check_level_up()
-                self.altar.pokemon_bodies += 1
+                self.__process_player_win()
                 # Gegner Pokemon austauschen bzw Game Over
                 self.enemy_poke_team.remove(self.enemy_active_poke)
-                if len(self.enemy_poke_team) >= 1:
+                if not self.__team_dead(self.enemy_poke_team):
                     self.enemy_active_poke = self.enemy_poke_team[0]
                 else:
                     return "game_over_enemy"
@@ -63,54 +91,48 @@ class Battle:
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             if self.enemy_move == "attack_physic":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_physic()  # Gegnerattacke
-                if self.spieler_active_poke.currentkp <= 0:
+                self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                self.spieler_active_poke)
+                if self.__active_fainted(self.spieler_active_poke):
                     # Spieler Pokemon austauschen bzw Game Over
-                    moved_pokemon = self.spieler_active_poke
-                    self.spieler_poke_team.remove(moved_pokemon)
-                    self.player_dead_pokemon.append(moved_pokemon)
-                    if len(self.spieler_poke_team) >= 1:
+                    self.__process_fainted(self.spieler_active_poke)
+                    if not self.__team_dead(self.spieler_poke_team):
                         self.spieler_active_poke = self.spieler_poke_team[0]
                     else:
                         return "game_over_player"
                 else:
                     # Schaden der Spielerattacke wird berechnet
-                    spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.atk * self.spieler_active_poke.attacken[0].atkdmg / (10 * self.enemy_active_poke.defence), 2)
-                    self.enemy_active_poke.currentkp -= spieler_dmg
+                    self.enemy_active_poke.currentkp -= self.__calc_damage_physic(self.spieler_active_poke,
+                                                                                  self.enemy_active_poke)
                     if self.enemy_active_poke.currentkp < 0:
                         # EP an aktives Spieler Pokemon geben
-                        self.spieler_active_poke.ep += 100
-                        self.spieler_active_poke.check_level_up()
-                        self.altar.pokemon_bodies += 1
+                        self.__process_player_win()
                         # Gegner Pokemon austauschen bzw Game Over
                         self.enemy_poke_team.remove(self.enemy_active_poke)
-                        if len(self.enemy_poke_team) >= 1:
+                        if not self.__team_dead(self.enemy_poke_team):
                             self.enemy_active_poke = self.enemy_poke_team[0]
                         else:
                             return "game_over_enemy"
             elif self.enemy_move == "attack_special":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_special()  # Gegnerattacke
-                if self.spieler_active_poke.currentkp <= 0:
+                self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                 self.spieler_active_poke)
+                if self.__active_fainted(self.spieler_active_poke):
                     # Spieler Pokemon austauschen bzw Game Over
-                    moved_pokemon = self.spieler_active_poke
-                    self.spieler_poke_team.remove(moved_pokemon)
-                    self.player_dead_pokemon.append(moved_pokemon)
-                    if len(self.spieler_poke_team) >= 1:
+                    self.__process_fainted(self.spieler_active_poke)
+                    if not self.__team_dead(self.spieler_poke_team):
                         self.spieler_active_poke = self.spieler_poke_team[0]
                     else:
                         return "game_over_player"
                 else:
                     # Schaden der Spielerattacke wird berechnet
-                    spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.atk * self.spieler_active_poke.attacken[0].atkdmg / (10 * self.enemy_active_poke.defence), 2)
-                    self.enemy_active_poke.currentkp -= spieler_dmg
+                    self.enemy_active_poke.currentkp -= self.__calc_damage_physic(self.spieler_active_poke,
+                                                                                   self.enemy_active_poke)
                     if self.enemy_active_poke.currentkp < 0:
                         # EP an aktives Spieler Pokemon geben
-                        self.spieler_active_poke.ep += 100
-                        self.spieler_active_poke.check_level_up()
-                        self.altar.pokemon_bodies += 1
+                        self.__process_player_win()
                         # Gegner Pokemon austauschen bzw Game Over
                         self.enemy_poke_team.remove(self.enemy_active_poke)
-                        if len(self.enemy_poke_team) >= 1:
+                        if not self.__team_dead(self.enemy_poke_team):
                             self.enemy_active_poke = self.enemy_poke_team[0]
                         else:
                             return "game_over_enemy"
@@ -126,41 +148,41 @@ class Battle:
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             # Schaden der Spielerattacke wird berechnet
-            spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.spatk * self.spieler_active_poke.attacken[1].atkdmg / (10 * self.enemy_active_poke.spdef), 2)
-            self.enemy_active_poke.currentkp -= spieler_dmg
+            self.enemy_active_poke.currentkp -= self.__calc_damage_special(self.spieler_active_poke,
+                                                                           self.enemy_active_poke)
             if self.enemy_active_poke.currentkp > 0:
                 # Gegner hat überlebt -> physiche Attacke
                 if self.enemy_move == "attack_physic":
-                    self.spieler_active_poke.currentkp -= self.enemy_attack_physic()    # Gegnerattacke
-                    if self.spieler_active_poke.currentkp <= 0:
+                    self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                    self.spieler_active_poke)
+                    if self.__active_fainted(self.spieler_active_poke):
                         # Spieler Pokemon austauschen bzw Game Over
                         moved_pokemon = self.spieler_active_poke
                         self.spieler_poke_team.remove(moved_pokemon)
                         self.player_dead_pokemon.append(moved_pokemon)
-                        if len(self.spieler_poke_team) >= 1:
+                        if not self.__team_dead(self.spieler_poke_team):
                             self.spieler_active_poke = self.spieler_poke_team[0]
                         else:
                             return "game_over_player"
                 # Gegner hat überlebt -> spezial-Attacke
                 elif self.enemy_move == "attack_special":
-                    self.spieler_active_poke.currentkp -= self.enemy_attack_special()   # Gegnerattacke
-                    if self.spieler_active_poke.currentkp <= 0:
+                    self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                     self.spieler_active_poke)
+                    if self.__active_fainted(self.spieler_active_poke):
                         # Spieler Pokemon austauschen bzw Game Over
                         moved_pokemon = self.spieler_active_poke
                         self.spieler_poke_team.remove(moved_pokemon)
                         self.player_dead_pokemon.append(moved_pokemon)
-                        if len(self.spieler_poke_team) >= 1:
+                        if not self.__team_dead(self.spieler_poke_team):
                             self.spieler_active_poke = self.spieler_poke_team[0]
                         else:
                             return "game_over_player"
             else:
                 # EP an aktives Spieler Pokemon geben
-                self.spieler_active_poke.ep += 100
-                self.spieler_active_poke.check_level_up()
-                self.altar.pokemon_bodies += 1
+                self.__process_player_win()
                 # Gegner Pokemon austauschen bzw Game Over
                 self.enemy_poke_team.remove(self.enemy_active_poke)
-                if len(self.enemy_poke_team) >= 1:
+                if not self.__team_dead(self.enemy_poke_team):
                     self.enemy_active_poke = self.enemy_poke_team[0]
                 else:
                     return "game_over_enemy"
@@ -169,54 +191,48 @@ class Battle:
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             if self.enemy_move == "attack_physic":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_physic()  # Gegnerattacke
-                if self.spieler_active_poke.currentkp <= 0:
+                self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                self.spieler_active_poke)
+                if self.__active_fainted(self.spieler_active_poke):
                     # Spieler Pokemon austauschen bzw Game Over
-                    moved_pokemon = self.spieler_active_poke
-                    self.spieler_poke_team.remove(moved_pokemon)
-                    self.player_dead_pokemon.append(moved_pokemon)
-                    if len(self.spieler_poke_team) >= 1:
+                    self.__process_fainted(self.spieler_active_poke)
+                    if not self.__team_dead(self.spieler_poke_team):
                         self.spieler_active_poke = self.spieler_poke_team[0]
                     else:
                         return "game_over_player"
                 else:
                     # Schaden der Spielerattacke wird berechnet
-                    spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.spatk * self.spieler_active_poke.attacken[1].atkdmg / (10 * self.enemy_active_poke.spdef), 2)
-                    self.enemy_active_poke.currentkp -= spieler_dmg
+                    self.enemy_active_poke.currentkp -= self.__calc_damage_special(self.spieler_active_poke,
+                                                                                   self.enemy_active_poke)
                     if self.enemy_active_poke.currentkp < 0:
                         # EP an aktives Spieler Pokemon geben und Levelup checken
-                        self.spieler_active_poke.ep += 100
-                        self.spieler_active_poke.check_level_up()
-                        self.altar.pokemon_bodies += 1
+                        self.__process_player_win()
                         # Gegner Pokemon austauschen bzw Game Over
                         self.enemy_poke_team.remove(self.enemy_active_poke)
-                        if len(self.enemy_poke_team) >= 1:
+                        if not self.__team_dead(self.enemy_poke_team):
                             self.enemy_active_poke = self.enemy_poke_team[0]
                         else:
                             return "game_over_enemy"
             elif self.enemy_move == "attack_special":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_special()  # Gegnerattacke
-                if self.spieler_active_poke.currentkp <= 0:
+                self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                 self.spieler_active_poke)
+                if self.__active_fainted(self.spieler_active_poke):
                     # Spieler Pokemon austauschen bzw Game Over
-                    moved_pokemon = self.spieler_active_poke
-                    self.spieler_poke_team.remove(moved_pokemon)
-                    self.player_dead_pokemon.append(moved_pokemon)
-                    if len(self.spieler_poke_team) >= 1:
+                    self.__process_fainted(self.spieler_active_poke)
+                    if not self.__team_dead(self.spieler_poke_team):
                         self.spieler_active_poke = self.spieler_poke_team[0]
                     else:
                         return "game_over_player"
                 else:
                     # Schaden der Spielerattacke wird berechnet
-                    spieler_dmg = round((self.spieler_active_poke.level * 0.4 + 2) * self.spieler_active_poke.spatk * self.spieler_active_poke.attacken[1].atkdmg / (10 * self.enemy_active_poke.spdef), 2)
-                    self.enemy_active_poke.currentkp -= spieler_dmg
+                    self.enemy_active_poke.currentkp -= self.__calc_damage_special(self.spieler_active_poke,
+                                                                                   self.enemy_active_poke)
                     if self.enemy_active_poke.currentkp < 0:
                         # EP an aktives Spieler Pokemon geben
-                        self.spieler_active_poke.ep += 100
-                        self.spieler_active_poke.check_level_up()
-                        self.altar.pokemon_bodies += 1
+                        self.__process_player_win()
                         # Gegner Pokemon austauschen bzw Game Over
                         self.enemy_poke_team.remove(self.enemy_active_poke)
-                        if len(self.enemy_poke_team) >= 1:
+                        if not self.__team_dead(self.enemy_poke_team):
                             self.enemy_active_poke = self.enemy_poke_team[0]
                         else:
                             return "game_over_enemy"
@@ -230,24 +246,22 @@ class Battle:
             enemy_moves = ["attack_physic", "attack_special"]
             self.enemy_move = random.choice(enemy_moves)
             if self.enemy_move == "attack_physic":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_physic()  # Gegnerattacke
-                if self.spieler_active_poke.currentkp <= 0:
+                self.spieler_active_poke.currentkp -= self.__calc_damage_physic(self.enemy_active_poke,
+                                                                                self.spieler_active_poke)
+                if self.__active_fainted(self.spieler_active_poke):
                     # Spieler Pokemon austauschen bzw Game Over
-                    moved_pokemon = self.spieler_active_poke
-                    self.spieler_poke_team.remove(moved_pokemon)
-                    self.player_dead_pokemon.append(moved_pokemon)
-                    if len(self.spieler_poke_team) >= 1:
+                    self.__process_fainted(self.spieler_active_poke)
+                    if not self.__team_dead(self.spieler_poke_team):
                         self.spieler_active_poke = self.spieler_poke_team[0]
                     else:
                         return "game_over_player"
             elif self.enemy_move == "attack_special":
-                self.spieler_active_poke.currentkp -= self.enemy_attack_special()  # Gegnerattacke
-                if self.spieler_active_poke.currentkp <= 0:
+                self.spieler_active_poke.currentkp -= self.__calc_damage_special(self.enemy_active_poke,
+                                                                                 self.spieler_active_poke)
+                if self.__active_fainted(self.spieler_active_poke):
                     # Spieler Pokemon austauschen bzw Game Over
-                    moved_pokemon = self.spieler_active_poke
-                    self.spieler_poke_team.remove(moved_pokemon)
-                    self.player_dead_pokemon.append(moved_pokemon)
-                    if len(self.spieler_poke_team) >= 1:
+                    self.__process_fainted(self.spieler_active_poke)
+                    if not self.__team_dead(self.spieler_poke_team):
                         self.spieler_active_poke = self.spieler_poke_team[0]
                     else:
                         return "game_over_player"
@@ -269,11 +283,3 @@ class Battle:
             healed_pokemon = self.spieler_poke_team[count]
             healed_pokemon.currentkp = healed_pokemon.maxkp
             count += 1
-
-    def enemy_attack_physic(self):
-        enemy_dmg = round((self.enemy_active_poke.level * 0.4 + 2) * self.enemy_active_poke.atk * self.enemy_active_poke.attacken[0].atkdmg / (10 * self.spieler_active_poke.defence), 2)
-        return enemy_dmg
-
-    def enemy_attack_special(self):
-        enemy_dmg = round((self.enemy_active_poke.level * 0.4 + 2) * self.enemy_active_poke.spatk * self.enemy_active_poke.attacken[1].atkdmg / (10 * self.spieler_active_poke.spdef), 2)
-        return enemy_dmg


### PR DESCRIPTION
Neue Methoden zur Schadenskalkulation, Rundenende und Fainted-Checks zur verhinderung von wiederholtem code.
Schadenskalkulation kann nun von Spieler und Computer benutzt werden, anstatt separat.

Optimal wäre komplettes Refactoring der player_attack Methoden, was aber relativ umständlich wäre.


(Ebenfalls kleiner Fix im der in letzter Pull-Request übersehen wurde.)

```
    def __active_fainted(self, active_pokemon) -> bool:
        if active_pokemon.currentkp < 0:
            active_pokemon.currentkp = 0
            return True
        return False

    def __team_dead(self, team) -> bool:
        if len(team) <= 0:
            return True
        return False

    def __process_fainted(self, active_pokemon) -> None:
        self.player_dead_pokemon.append(active_pokemon)
        self.spieler_poke_team.remove(active_pokemon)

    def __process_player_win(self) -> None:
        self.spieler_active_poke.ep += 100
        self.spieler_active_poke.check_level_up()
        self.altar.pokemon_bodies += 1
```

Habe damit mein Soll erfüllt, glhf